### PR TITLE
[update] view model 명칭 및 directory 구조 추가

### DIFF
--- a/src/main/java/com/chwimong/project/employment/ui/controller/CompactEmploymentController.java
+++ b/src/main/java/com/chwimong/project/employment/ui/controller/CompactEmploymentController.java
@@ -10,8 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import com.chwimong.project.employment.exception.ChwimongException;
 import com.chwimong.project.employment.exception.MessageType;
 import com.chwimong.project.employment.ui.view.ApiResponseView;
-import com.chwimong.project.employment.ui.view.EmploymentKeywordListView;
-import com.chwimong.project.employment.ui.view.EmploymentSummaryListView;
+import com.chwimong.project.employment.ui.view.filterSystem.EmploymentJobFilteringListView;
+import com.chwimong.project.employment.ui.view.filterSystem.EmploymentKeywordExtractionListView;
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -34,7 +34,7 @@ public class CompactEmploymentController {
 
     @GetMapping("")
     @Operation(summary = "직무명 필터링용 요약 채용정보 조회", description = "조건에 따른 요약 채용정보 목록을 조회")
-    public ResponseEntity<ApiResponseView<EmploymentSummaryListView>> getCompactEmploymentsForFiltering(
+    public ResponseEntity<ApiResponseView<EmploymentJobFilteringListView>> getCompactEmploymentsForFiltering(
     		@RequestParam(value = "jobtitle", required = false) String jobtitle
     ) {
     	
@@ -42,8 +42,8 @@ public class CompactEmploymentController {
     		var query = new EmploymentFindUseCase.EmploymentWithCategoryQuery(jobtitle);
     		var employmentResults = employmentFindUseCase.getEmploymentsWithCategory(query);
     		
-    		EmploymentSummaryListView summaryListView = new EmploymentSummaryListView(employmentResults);
-    		ApiResponseView<EmploymentSummaryListView> responseView = new ApiResponseView<>(summaryListView);
+    		EmploymentJobFilteringListView summaryListView = new EmploymentJobFilteringListView(employmentResults);
+    		ApiResponseView<EmploymentJobFilteringListView> responseView = new ApiResponseView<>(summaryListView);
     		
     		return ResponseEntity.ok(responseView);
     		
@@ -55,7 +55,7 @@ public class CompactEmploymentController {
     
     @GetMapping("/keyword")
     @Operation(summary = "키워드 추출용 요약 채용정보 조회", description = "조건에 따른 요약 채용정보 목록을 조회")
-    public ResponseEntity<ApiResponseView<EmploymentKeywordListView>> getCompactEmploymentsForKeyword(
+    public ResponseEntity<ApiResponseView<EmploymentKeywordExtractionListView>> getCompactEmploymentsForKeyword(
     		@RequestParam(value = "keyword", required = false) String keyword
 	) {
     	
@@ -63,8 +63,8 @@ public class CompactEmploymentController {
     		var query = new EmploymentFindUseCase.EmploymentWithKeywordQuery(keyword);
     		var employmentResults = employmentFindUseCase.getEmploymentsWithKeyword(query);
     		
-    		EmploymentKeywordListView keywordListView = new EmploymentKeywordListView(employmentResults);
-    		ApiResponseView<EmploymentKeywordListView> responseView = new ApiResponseView<>(keywordListView);
+    		EmploymentKeywordExtractionListView keywordListView = new EmploymentKeywordExtractionListView(employmentResults);
+    		ApiResponseView<EmploymentKeywordExtractionListView> responseView = new ApiResponseView<>(keywordListView);
     		
     		return ResponseEntity.ok(responseView);
     		

--- a/src/main/java/com/chwimong/project/employment/ui/controller/EmploymentController.java
+++ b/src/main/java/com/chwimong/project/employment/ui/controller/EmploymentController.java
@@ -16,8 +16,8 @@ import com.chwimong.project.employment.ui.request.FindEmploymentRequest;
 import com.chwimong.project.employment.ui.view.ApiResponseView;
 import com.chwimong.project.employment.ui.view.EmploymentCountListView;
 import com.chwimong.project.employment.ui.view.EmploymentKeywordTrendListView;
+import com.chwimong.project.employment.ui.view.client.EmploymentListView;
 import com.chwimong.project.employment.ui.view.EmploymentKeywordMapListByJobtitleView;
-import com.chwimong.project.employment.ui.view.EmploymentListView;
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase;
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase.EmploymentFindQuery;
 

--- a/src/main/java/com/chwimong/project/employment/ui/view/client/EmploymentListView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/client/EmploymentListView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.client;
 
 import java.util.List;
 import java.util.stream.Collectors;

--- a/src/main/java/com/chwimong/project/employment/ui/view/client/EmploymentView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/client/EmploymentView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.client;
 
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase;
 

--- a/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentJobFilteringListView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentJobFilteringListView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.filterSystem;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,14 +11,14 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class EmploymentSummaryListView {
+public class EmploymentJobFilteringListView {
 	
 	@JsonValue
-    private List<EmploymentSummaryView> summaryViewList;
+    private List<EmploymentJobFilteringView> summaryViewList;
 
-    public EmploymentSummaryListView(List<FindEmploymentResult> results) {
+    public EmploymentJobFilteringListView(List<FindEmploymentResult> results) {
         this.summaryViewList = results.stream()
-            .map(EmploymentSummaryView::new)
+            .map(EmploymentJobFilteringView::new)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentJobFilteringView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentJobFilteringView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.filterSystem;
 
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -8,7 +8,7 @@ import lombok.ToString;
 @Getter
 @ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class EmploymentSummaryView {
+public class EmploymentJobFilteringView {
 	
     private String id;
     private String main;
@@ -16,7 +16,7 @@ public class EmploymentSummaryView {
     private String thanks;
     private String fullTxt;
 
-    public EmploymentSummaryView(EmploymentFindUseCase.FindEmploymentResult result) {
+    public EmploymentJobFilteringView(EmploymentFindUseCase.FindEmploymentResult result) {
         this.id = result.getId();
         this.main = result.getMain();
         this.require = result.getRequire();

--- a/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentKeywordExtractionListView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentKeywordExtractionListView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.filterSystem;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -11,14 +11,14 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class EmploymentKeywordListView {
+public class EmploymentKeywordExtractionListView {
 
 	@JsonValue
-	private List<EmploymentKeywordView> keywordViewList;
+	private List<EmploymentKeywordExtractionView> keywordViewList;
 	
-	public EmploymentKeywordListView(List<FindEmploymentResult> results) {
+	public EmploymentKeywordExtractionListView(List<FindEmploymentResult> results) {
 		this.keywordViewList = results.stream()
-			.map(EmploymentKeywordView::new)
+			.map(EmploymentKeywordExtractionView::new)
 			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentKeywordExtractionView.java
+++ b/src/main/java/com/chwimong/project/employment/ui/view/filterSystem/EmploymentKeywordExtractionView.java
@@ -1,4 +1,4 @@
-package com.chwimong.project.employment.ui.view;
+package com.chwimong.project.employment.ui.view.filterSystem;
 
 import com.chwimong.project.employment.usecase.EmploymentFindUseCase;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -9,13 +9,13 @@ import lombok.ToString;
 @Getter
 @ToString
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class EmploymentKeywordView {
+public class EmploymentKeywordExtractionView {
 
 	private String id;
 	private String thanks;
 	private String require;
 	
-	public EmploymentKeywordView(EmploymentFindUseCase.FindEmploymentResult result) {
+	public EmploymentKeywordExtractionView(EmploymentFindUseCase.FindEmploymentResult result) {
 		this.id = result.getId();
 		this.thanks = result.getThanks();
 		this.require = result.getRequire();


### PR DESCRIPTION
[직무명 필터링]
EmploymentSummaryView -> EmploymentJobFilteringView
EmploymentSummaryListView -> EmploymentJobFilteringListView

[키워드 추출]
EmploymentKeywordView -> EmploymentKeywordExtractionView
EmploymentKeywordListView -> EmploymentKeywordExtractionListView

* view model의 용도를 명확하기 위한 명칭 재정의
* 04/10 멘토링 : Info 또는 Data등의 유의미하지 않은 Postfix 지양
* view model 증가로 인해 client 및 filterSystem등의 용도에 따른 directory 분리

@creaton60 